### PR TITLE
Fix breaking change on latest version of osu!

### DIFF
--- a/osu.Game.Rulesets.Gamebosu.Tests/VisualTestRunner.cs
+++ b/osu.Game.Rulesets.Gamebosu.Tests/VisualTestRunner.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Gamebosu.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { BindIPC = true }))
             {
                 host.Run(new OsuTestBrowser());
                 return 0;

--- a/osu.Game.Rulesets.Gamebosu/Replays/GamebosuFramedReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Gamebosu/Replays/GamebosuFramedReplayInputHandler.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Gamebosu.Replays
 
         protected override bool IsImportant(GamebosuReplayFrame frame) => frame.Actions.Any();
 
-        public override void CollectPendingInputs(List<IInput> inputs)
+        protected override void CollectReplayInputs(List<IInput> inputs)
         {
         }
     }

--- a/osu.Game.Rulesets.Gamebosu/osu.Game.Rulesets.Gamebosu.csproj
+++ b/osu.Game.Rulesets.Gamebosu/osu.Game.Rulesets.Gamebosu.csproj
@@ -10,7 +10,7 @@
     <EmbeddedResource Include="Resources\**\*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2022.128.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2022.205.0" />
     <ProjectReference Include="..\Emux\Emux.GameBoy\Emux.GameBoy.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
Hi! This pull request is fixing the breaking change from latest version of osu!

- Bump osu! version
- Fix replay breaking change by change accessibility from `public` to `protected` and change method name to latest name `CollectReplayInputs`

I also fix the obsolete warning during the release build

`VisualTestRunner.cs(16, 43): [CS0618] 'Host.GetSuitableHost(string, bool, bool)' is obsolete: 'Use GetSuitableDesktopHost(string, HostOptions) instead.'`
