### PR TITLE
use correct framework

### DIFF
--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
 
     <!-- Make sure start same folder .NET Core CLI and Visual Studio -->

--- a/osu.Game.Rulesets.Gamebosu.Tests/osu.Game.Rulesets.Gamebosu.Tests.csproj
+++ b/osu.Game.Rulesets.Gamebosu.Tests/osu.Game.Rulesets.Gamebosu.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>osu.Game.Rulesets.Gamebosu.Tests</RootNamespace>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)